### PR TITLE
ARGO-2512 Token handling in SuperAdmin POEM

### DIFF
--- a/poem/Poem/frontend/react/Administration.js
+++ b/poem/Poem/frontend/react/Administration.js
@@ -122,5 +122,15 @@ export const SuperAdminAdministration = (props) =>
         </Row>
       </CardBody>
     </Card>
+    <Card>
+      <CardHeader className="mt-2 p-2 text-light text-uppercase rounded" style={{'backgroundColor': "#416090"}}>
+        API key permissions
+      </CardHeader>
+      <CardBody>
+        <Row className="p-1 align-items-center">
+          <Icon i="apikey"/> <Link to={'/ui/administration/apikey'}>API keys</Link>
+        </Row>
+      </CardBody>
+    </Card>
   </Form>
 )

--- a/poem/Poem/frontend/react/App.js
+++ b/poem/Poem/frontend/react/App.js
@@ -318,6 +318,13 @@ const SuperAdminRouteSwitch = ({props}) => (
     <Route exact path="/ui/administration/users/:user_name"
       render={props => <SuperAdminUserChange {...props}/>}
     />
+    <Route exact path="/ui/administration/apikey" component={APIKeyList} />
+    <Route exact path="/ui/administration/apikey/add"
+      render={props => <APIKeyChange {...props} addview={true}/>}
+    />
+    <Route exact path="/ui/administration/apikey/:name"
+      render={props => <APIKeyChange {...props} />}
+    />
     <Route component={NotFound} />
   </Switch>
 )

--- a/poem/Poem/settings.py
+++ b/poem/Poem/settings.py
@@ -95,6 +95,7 @@ SHARED_APPS = (
     'rest_auth',
     'Poem.users',
     'Poem.poem_super_admin',
+    'Poem.api',
 )
 
 TENANT_APPS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-rest-auth==0.9.5
 git+https://github.com/vrdel/django-tenant-schemas
 django-webpack-loader==0.7.0
 djangorestframework==3.11.0
-djangorestframework-api-key==1.4.1
+djangorestframework-api-key==2.0.0
 djangosaml2==0.18.1
 dparse==0.5.0
 filelock==3.0.12


### PR DESCRIPTION
@vrdel When you deploy this, please do the following:

1. Manually delete entry in `django.migration` table in **public** schema for `api` app. For some reason, it is marked as run, even though it's table is only created in tenant schemas.

2. Run `../manage.py migrate_schemas --shared`. This will create `api.myapikey` table in public schema.

Also, don't forget to upgrade `djangorestframework-api-key`. 