### PR TITLE
Version 3.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [3.4.5] - 2022-11-03
+
+### Added
+
+* ARGO-3971 Store default ports in POEM
+* ARGO-3980 Support bulk delete of service types
+* ARGO-3981 Introduce bulk add service types view
+* ARGO-3983 Add service types pagination
+* ARGO-4009 Enable Hot Module Replacement and Django internal web server
+* ARGO-4014 Define min and max width of name column in Service Types list
+
+### Changed
+
+* ARGO-3711 Reduce Metric model to what is strictly necessary
+* ARGO-3982 Remove service types sync and related DB tables
+* ARGO-4004 Ensure that only service type names without whitespace can created from the UI
+* ARGO-4008 Have red border around changed description field
+* ARGO-4012 One common Save button instead of one in every row
+* ARGO-4031 Switch API key page to react-hook-form library
+* ARGO-4032 Switch groups page to react-hook-form library
+* ARGO-4039 Switch package page to react-hook-form library
+* ARGO-4051 Ensure POEM wheel essential dependencies installed automatically
+
+### Fixed
+
+* ARGO-4005 Marking field tuple on filtered view ends with description fields populated from neighboring tuple
+* ARGO-4006 Case insensitive search on bulk delete and placeholder missing
+* ARGO-4028 Adding of new metric profile is broken
+* ARGO-4094 Metric parameter overrides not handling space in parameter value
+* ARGO-4095 Clean requirements.txt
+
 ## [3.4.4] - 2022-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Web application is served with Apache web server and uses PostgreSQL as database
 
 Backend: `Django`, `dj-rest-auth`, `django-tenants`, `django-webpack-loader`, `djangorestframework`, `djangorestframework-api-key`, `djangosaml2`, `psycopg2-binary`
 
-Frontend: `ReactJS`, `formik`, `react-autosuggest`, `react-diff-viewer`, `react-dom`, `react-fontawesome`, `react-helmet`, `react-notifications`, `react-popup`, `react-router`, `react-select`, `react-table`, `reactstrap`, `webpack`, `yup`
+Frontend: `ReactJS`, `formik`, `react-hook-form`, `react-autosuggest`, `react-diff-viewer`, `react-dom`, `react-fontawesome`, `react-helmet`, `react-notifications`, `react-popup`, `react-router`, `react-select`, `react-table`, `reactstrap`, `webpack`, `yup`
 
 ## User documentation and instances
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def get_files(install_prefix, directory):
 
 
 setup(name=NAME,
-      version='3.4.4',
+      version='3.4.5',
       description='Reports, Profiles, Probes and Metric Configuration Management (POEM) for ARGO Monitoring framework.',
       author='SRCE',
       author_email='dvrcic@srce.hr, kzailac@srce.hr',


### PR DESCRIPTION
### Added

* ARGO-3971 Store default ports in POEM
* ARGO-3980 Support bulk delete of service types
* ARGO-3981 Introduce bulk add service types view
* ARGO-3983 Add service types pagination
* ARGO-4009 Enable Hot Module Replacement and Django internal web server
* ARGO-4014 Define min and max width of name column in Service Types list

### Changed

* ARGO-3711 Reduce Metric model to what is strictly necessary
* ARGO-3982 Remove service types sync and related DB tables
* ARGO-4004 Ensure that only service type names without whitespace can created from the UI
* ARGO-4008 Have red border around changed description field
* ARGO-4012 One common Save button instead of one in every row
* ARGO-4031 Switch API key page to react-hook-form library
* ARGO-4032 Switch groups page to react-hook-form library
* ARGO-4039 Switch package page to react-hook-form library
* ARGO-4051 Ensure POEM wheel essential dependencies installed automatically

### Fixed

* ARGO-4005 Marking field tuple on filtered view ends with description fields populated from neighboring tuple
* ARGO-4006 Case insensitive search on bulk delete and placeholder missing
* ARGO-4028 Adding of new metric profile is broken
* ARGO-4094 Metric parameter overrides not handling space in parameter value
* ARGO-4095 Clean requirements.txt